### PR TITLE
maelstro: add custom liveness and initialdelay to 45

### DIFF
--- a/maelstro/Chart.yaml
+++ b/maelstro/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/maelstro/templates/maelstro-backend-deployment.yaml
+++ b/maelstro/templates/maelstro-backend-deployment.yaml
@@ -39,10 +39,15 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
+          {{- if .Values.custom_liveness_probe }}
+          {{ .Values.custom_liveness_probe | toYaml | nindent 10 }}
+          {{- else }}
           livenessProbe:
             httpGet:
               path: /health
               port: http
+            initialDelaySeconds: 45
+          {{- end }}
           readinessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
Pod was destroyed before backend starts

- Added a custom liveness in values
- Added an initialDelaySeconds to 45 by default