### PR TITLE
chore: stop bitnami docker image usage + move bitnami charts local

### DIFF
--- a/georchestra/CHANGELOG.md
+++ b/georchestra/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.11.0
 
-Move away from Bitnami Docker images and migrate Bitnami helm charts to our Docker registry.
+Migrate Bitnami helm charts to our Docker registry.
 
 # 1.10.0
 

--- a/georchestra/CHANGELOG.md
+++ b/georchestra/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.11.0
+
+Move away from Bitnami Docker images and migrate Bitnami helm charts to our Docker registry.
+
 # 1.10.0
 
 - For the Helm dependencies, switch from bitnamicharts to bitnamichartslegacy due to https://github.com/bitnami/containers/issues/83267

--- a/georchestra/Chart.lock
+++ b/georchestra/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
-  repository: oci://registry-1.docker.io/bitnamichartslegacy
+  repository: oci://ghcr.io/georchestra/bitnami-helm-charts
   version: 15.5.2
 - name: rabbitmq
-  repository: oci://registry-1.docker.io/bitnamichartslegacy
+  repository: oci://ghcr.io/georchestra/bitnami-helm-charts
   version: 14.4.0
-digest: sha256:0d041037017b3f7e67ac69590f792c27688a2dfd4145f564a0034e9bf97a300b
-generated: "2025-08-20T14:08:03.980699455+02:00"
+digest: sha256:ccc78c2bf311b8d0fa8045bc0554e01ffaf52bd4bb9aaf7fefada5543055d464
+generated: "2025-09-01T11:05:34.650331473+02:00"

--- a/georchestra/Chart.yaml
+++ b/georchestra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.0
+version: 1.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -26,11 +26,11 @@ appVersion: "24.0"
 dependencies:
 - name: postgresql
   version: 15.5.2
-  repository: "oci://registry-1.docker.io/bitnamichartslegacy"
+  repository: "oci://ghcr.io/georchestra/bitnami-helm-charts"
   condition: database.builtin
   alias: database
 - name: rabbitmq
   version: 14.4.0
-  repository: "oci://registry-1.docker.io/bitnamichartslegacy"
+  repository: "oci://ghcr.io/georchestra/bitnami-helm-charts"
   condition: rabbitmq.enabled, rabbitmq.builtin
   alias: rabbitmq

--- a/georchestra/values.yaml
+++ b/georchestra/values.yaml
@@ -506,10 +506,6 @@ database:
 rabbitmq:
   enabled: false
   builtin: true
-  image:
-    registry: docker.io
-    repository: rabbitmq
-    tag: 3.13.7
   auth:
     username: georchestra
     password: georchestra

--- a/georchestra/values.yaml
+++ b/georchestra/values.yaml
@@ -506,6 +506,10 @@ database:
 rabbitmq:
   enabled: false
   builtin: true
+  image:
+    registry: docker.io
+    repository: rabbitmq
+    tag: 3.13.7
   auth:
     username: georchestra
     password: georchestra


### PR DESCRIPTION
- Move bitnami charts to our own registry:
	- https://github.com/orgs/georchestra/packages/container/package/bitnami-helm-charts%2Frabbitmq
	- https://github.com/orgs/georchestra/packages/container/package/bitnami-helm-charts%2Fpostgresql
- Stop using Bitnami docker images 